### PR TITLE
Fix use of bodyAttrs in theme:body tag

### DIFF
--- a/grails-app/taglib/org/grails/plugin/platform/ThemeTagLib.groovy
+++ b/grails-app/taglib/org/grails/plugin/platform/ThemeTagLib.groovy
@@ -310,13 +310,13 @@ class ThemeTagLib {
         def bodyAttrs = attrs.bodyAttrs
         def bodyAttrsStr = ''
         if (bodyAttrs instanceof Map) {
-            bodyAttrsStr = HTMLTagLib.attrsToString(bodyAttrs)
+            bodyAttrsStr = TagLibUtils.attrsToString(bodyAttrs)
         } else if (bodyAttrs instanceof List) {
             def bodyAttrsMap = [:]
             bodyAttrs.each { p -> bodyAttrsMap[p] = g.pageProperty(name:'body.'+p) }
-            bodyAttrsStr = HTMLTagLib.attrsToString(bodyAttrsMap)
+            bodyAttrsStr = TagLibUtils.attrsToString(bodyAttrsMap)
         }
-        out << "<body${bodyAttrsStr}>"
+        out << "<body ${bodyAttrsStr}>"
         if (isDebugModeOn()) {
             // We need the body of the debug GSP as it has the panel in it
             // @todo we can probably ditch this layoutBody if theme previewer concats to "body" zone


### PR DESCRIPTION
Hi,

Currently using <theme:body bodyAttrs="[class: 'test']"> fails - specifically adding "bodyAttrs" hits invalid code.

This patch fixes the problem.

Simon
