### PR TITLE
Add an attempt to use i18n messages to resolve field names

### DIFF
--- a/grails-app/taglib/org/grails/plugin/platform/UITagLib.groovy
+++ b/grails-app/taglib/org/grails/plugin/platform/UITagLib.groovy
@@ -695,7 +695,9 @@ class UITagLib implements InitializingBean {
             def labelCode = attrs.remove('label')
             if (!labelCode && name) {
                 def propName = resolvePropertyName(name)
-                label = GrailsNameUtils.getNaturalName(propName)
+                label = p.text(code: "${GrailsNameUtils.getPropertyName(beanObject.getClass().simpleName)}.${propName}.label", default: '')
+                if(!label)
+                    label = GrailsNameUtils.getNaturalName(propName)
             }
             if ((labelCode == null) && !label) {
                 throwTagError "A value must be provided for [label] or [name] if no custom label is provided"


### PR DESCRIPTION
Hi,

Please consider this minor feature addition which adds an attempt to automatically resolve field labels from an i18n message.  It uses a naming scheme taken from the fields plugin.

Thanks
Simon
