### PR TITLE
Allows override the CSS classes used for UI Set elements on a per-theme basis

### DIFF
--- a/src/groovy/org/grails/plugin/platform/ui/UISets.groovy
+++ b/src/groovy/org/grails/plugin/platform/ui/UISets.groovy
@@ -225,13 +225,17 @@ class UISets implements ApplicationContextAware, InitializingBean {
     }
 
     String getUICSSClass(request, symbolicName, defaultValue = '') {
+        def theme = grailsThemes.getRequestTheme(request)
         def uiSets = getUISetsToUse(request)
         def v
         for (ui in uiSets) {
             if (log.debugEnabled) {
                 log.debug "Seeing if UI Set [${ui?.name}] has a CSS class for [${symbolicName}]"
             }
-            def confValue = pluginConfig.ui[ui.name][symbolicName].cssClass
+            def confValue = pluginConfig.themes."${theme.name}".ui."${symbolicName}".cssClass
+            if (confValue.isEmpty()) {
+                confValue = pluginConfig.ui[ui.name][symbolicName].cssClass
+            }
             if (!(confValue instanceof ConfigObject)) {
                 v = confValue
                 break


### PR DESCRIPTION
According to the project documents at http://platform-ui.org/doc/latest/guide/creatingThemes.html#themeConfiguration , cssClass defined in theme config should override cssClass defined in ui config.

But this didn't works in original code. This patch fix the problem.
